### PR TITLE
Lock down fog-google version to 0.5.2

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google",        ">=0.5.2"
+  s.add_dependency "fog-google",        "=0.5.2"
   s.add_dependency "google-api-client", "~>0.8.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
PR https://github.com/fog/fog-google/pull/222 broke snapshot listing in
our vcr cassettes which was released in 0.5.3.  Lock down fog-google to
0.5.2 until we re-record the cassette.