### PR TITLE
Decrypt JSON key in raw connect

### DIFF
--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -38,7 +38,7 @@ module ManageIQ::Providers::Google::ManagerMixin
       config = {
         :provider               => "Google",
         :google_project         => google_project,
-        :google_json_key_string => google_json_key,
+        :google_json_key_string => MiqPassword.try_decrypt(google_json_key),
         :app_name               => I18n.t("product.name"),
         :app_version            => Vmdb::Appliance.VERSION,
         :google_client_options  => {

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -1,4 +1,35 @@
 describe ManageIQ::Providers::Google::CloudManager do
+  context ".raw_connect" do
+    let(:config) do
+      {
+        :provider               => "Google",
+        :google_project         => "project",
+        :google_json_key_string => "encrypted",
+        :app_name               => I18n.t("product.name"),
+        :app_version            => Vmdb::Appliance.VERSION,
+        :google_client_options  => {
+          :proxy => "proxy_uri"
+        }
+      }
+    end
+
+    before do
+      require 'fog/google'
+    end
+
+    it "decrypts json keys" do
+      expect(::Fog::Compute).to receive(:new).with(config)
+
+      described_class.raw_connect("project", MiqPassword.encrypt("encrypted"), {:service => "compute"}, "proxy_uri")
+    end
+
+    it "works with unencrypted keys" do
+      expect(::Fog::Compute).to receive(:new).with(config)
+
+      described_class.raw_connect("project", "encrypted", {:service => "compute"}, "proxy_uri")
+    end
+  end
+
   it ".ems_type" do
     expect(described_class.ems_type).to eq('gce')
   end


### PR DESCRIPTION
Working on switching credential validation onto the queue using the class method `raw_connec`t to be able to validate in different zones and remove the use of a temporary EMS. This will require passwords to be encrypted / decrypted in raw_connect.

More info: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580