### PR TITLE
Workaround a bug in fog-google when there are no snapshots

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
@@ -53,7 +53,13 @@ module ManageIQ::Providers
       end
 
       def get_snapshots
-        snapshots = @connection.snapshots.all
+        snapshots =
+          begin
+            @connection.snapshots.all
+          rescue TypeError # Workaround for https://github.com/fog/fog-google/issues/239
+            []
+          end
+
         process_collection(snapshots, :cloud_volume_snapshots) { |snapshot| parse_snapshot(snapshot) }
         # Also pass the snapshots as templates
         process_collection(snapshots, :vms) { |snapshot| parse_storage_as_template(snapshot) }


### PR DESCRIPTION
There is a bug in fog-google which causes an exception to be raised when
there are no snapshots present on the provider causing the refresh
to fail.

Issue raised in fog-google here
https://github.com/fog/fog-google/issues/239

This can be removed once https://github.com/fog/fog-google/pull/240 is
merged and released.