### PR TITLE
Bump fog-google version for snapshot handling fix

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google",        ">=0.5.3"
+  s.add_dependency "fog-google",        ">=0.5.4"
   s.add_dependency "google-api-client", "~>0.8.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Fog-google 0.5.4 included a fix for listing snapshots when there were no
snapshots.

https://github.com/fog/fog-google/pull/240