### PR TITLE
Remove unused dependency on google-api-client

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "fog-google",        ">=0.5.4"
-  s.add_dependency "google-api-client", "~>0.8.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The google-api-client dependency was added originally for Oauth2 support
which has since been dropped.  It is not a runtime dependency of
fog-google which is used, and google-api-client 0.8.7 requires
activesupport < 5.0.