### PR TITLE
Add back google-api-client locked down to 0.8.6

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "fog-google",        ">=0.5.4"
+  s.add_dependency "google-api-client", "=0.8.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Reports of google-api-client being unused were premature :smile:

Without google-api-client, fog-google reports the following error:
```
WARN -- : MIQ(ManageIQ::Providers::Google::CloudManager#authentication_check_no_validation) type: ["service_account"] for [] [GCE] Validation failed: invalid, google has no compute service
```

We need to lock-down to `google-api-client 0.8.6` because in `0.8.7` they restrict `activesupport < 5.0` in [this commit](https://github.com/google/google-api-ruby-client/commit/fd295849b9409da87db170d60ccd3fed2bcb674c#diff-9f1ff4c0bfd372130043e66d2a89e887R35)