### PR TITLE
Add user data injection for cloud-init scripts for GCE

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -24,6 +24,11 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
     # issue: https://github.com/fog/fog-google/issues/136
     clone_options[:on_host_maintenance] = "TERMINATE" if clone_options[:preemptible]
 
+    if clone_options[:user_data]
+      clone_options[:metadata] = {"user-data"          => Base64.encode64(clone_options[:user_data]),
+                                  "user-data-encoding" => "base64"}
+    end
+
     clone_options
   end
 

--- a/spec/models/manageiq/providers/google/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/provision_spec.rb
@@ -1,0 +1,35 @@
+describe ManageIQ::Providers::Google::CloudManager::Provision do
+  let(:provider) { FactoryGirl.create(:ems_google_with_authentication) }
+
+  context "Cloning" do
+    describe "#prepare_for_clone_task" do
+      let(:user_data) { "simple test user data" }
+      let(:flavor) { FactoryGirl.create(:flavor_google) }
+      let(:availability_zone) { FactoryGirl.create(:availability_zone_google) }
+
+      before do
+        allow(subject).to receive(:instance_type).and_return(flavor)
+        allow(subject).to receive(:dest_availability_zone).and_return(availability_zone)
+        allow(subject).to receive(:validate_dest_name)
+      end
+
+      it "calls super" do
+        # can't test call to super, but we know :validate_dest_name is called in super
+        expect(subject).to receive(:validate_dest_name)
+        subject.prepare_for_clone_task
+      end
+
+      it "handles available user data" do
+        expect(subject).to receive(:userdata_payload).and_return(user_data)
+        clone_options = subject.prepare_for_clone_task
+        expect(clone_options[:metadata]["user-data-encoding"]).to eql("base64")
+        expect(clone_options[:metadata]["user-data"]).to eql(Base64.encode64(user_data))
+      end
+
+      it "handles absent user data" do
+        expect(subject).to receive(:userdata_payload).and_return(nil)
+        expect(subject.prepare_for_clone_task[:metadata]).to eql(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR maps the optional user data provisioned via MiQ into the GCE metadata hash.

cloud-init user data injection is supported on GCE via metadata. 

[manageiq PR 16192](https://github.com/ManageIQ/manageiq/pull/16192) will  enable the cloud-init user data injection from the MiQ dashboard for GCE.

This PR will not be adversely impacted if [manageiq PR 16192](https://github.com/ManageIQ/manageiq/pull/16192) is not available. The user_data injection functionality will simply not be available without it.


https://bugzilla.redhat.com/show_bug.cgi?id=1395757