### PR TITLE
Pinning fog-google to 0.5.4

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google",        ">=0.5.4"
+  s.add_dependency "fog-google",        "=0.5.4"
   s.add_dependency "google-api-client", "=0.8.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
As 0.6 is not yet working due to incompatible changes in metrics.

https://bugzilla.redhat.com/show_bug.cgi?id=1503921