### PR TITLE
Use VMDB::Appliance.PRODUCT_NAME not i18n method.

### DIFF
--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -27,7 +27,7 @@ module ManageIQ::Providers::Google::ManagerMixin
         :provider               => "Google",
         :google_project         => google_project,
         :google_json_key_string => MiqPassword.try_decrypt(google_json_key),
-        :app_name               => I18n.t("product.name"),
+        :app_name               => Vmdb::Appliance.PRODUCT_NAME,
         :app_version            => Vmdb::Appliance.VERSION,
         :google_client_options  => {
           :proxy => proxy_uri

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Google::CloudManager do
         :provider               => "Google",
         :google_project         => "project",
         :google_json_key_string => "encrypted",
-        :app_name               => I18n.t("product.name"),
+        :app_name               => Vmdb::Appliance.PRODUCT_NAME,
         :app_version            => Vmdb::Appliance.VERSION,
         :google_client_options  => {
           :proxy => "proxy_uri"


### PR DESCRIPTION
Since PR https://github.com/ManageIQ/manageiq/pull/16409
we now have a method for product name.