### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -45,6 +45,10 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     %w(auth_key)
   end
 
+  def supported_catalog_types
+    %w(google)
+  end
+
   # TODO(lwander) determine if user wants to use OAUTH or a service account
   def missing_credentials?(_type = {})
     false

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -110,4 +110,12 @@ describe ManageIQ::Providers::Google::CloudManager do
       end
     end
   end
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:ems_google) }
+
+    it "#supported_google_types" do
+      expect(ems.supported_catalog_types).to eq(%w(google))
+    end
+  end
 end


### PR DESCRIPTION
For Service Catalogs we need each provider to provide list of supported catalog types.

This is needed for PR https://github.com/ManageIQ/manageiq/pull/16559