### PR TITLE
Extend allowed_cloud_network for providers that don't support allowed_ci

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -5,6 +5,14 @@ class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvis
     ems.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
   end
 
+  def allowed_cloud_networks(_options = {})
+    return {} unless (src_obj = provider_or_tenant_object)
+
+    src_obj.all_cloud_networks.each_with_object({}) do |cn, hash|
+      hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
+    end
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/spec/models/manageiq/providers/google/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/provision_workflow_spec.rb
@@ -1,0 +1,51 @@
+describe ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow do
+  include Spec::Support::WorkflowHelper
+
+  let(:admin) { FactoryGirl.create(:user_with_group) }
+  let(:provider) do
+    allow(User).to receive_messages(:server_timezone => "UTC")
+    FactoryGirl.create(:ems_google)
+  end
+
+  let(:ems) { FactoryGirl.create(:ems_google) }
+  let(:template) { FactoryGirl.create(:template_google, :name => "template", :ext_management_system => ems) }
+  let(:workflow) do
+    stub_dialog
+    allow(User).to receive_messages(:server_timezone => "UTC")
+    wf = described_class.new({:src_vm_id => template.id}, admin.userid)
+    wf
+  end
+
+  context "with empty relationships" do
+    it "#allowed_cloud_networks" do
+      expect(workflow.allowed_cloud_networks).to eq({})
+    end
+  end
+
+  context "with valid relationships" do
+    it "#allowed_cloud_networks" do
+      cn = FactoryGirl.create(:cloud_network)
+      ems.cloud_networks << cn
+      expect(workflow.allowed_cloud_networks).to eq(cn.id => cn.name)
+    end
+  end
+
+  context "cloud networks" do
+    before do
+      @az1 = FactoryGirl.create(:availability_zone, :ext_management_system => ems)
+      FactoryGirl.create(:cloud_network_google, :ext_management_system => ems.network_manager)
+    end
+
+    context "#allowed_cloud_networks" do
+      it "without an Availability Zone" do
+        expect(workflow.allowed_cloud_networks.length).to eq(1)
+      end
+
+      it "with an Availability Zone" do
+        workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
+
+        expect(workflow.allowed_cloud_networks.length).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16811 adds RBAC filtering to allowed_cloud_network base class but two of the providers don't support the allowed_ci method so for them we need to overwrite the allowed_cloud_networks, to just return allowed_cloud_networks. Which this does! (Per https://github.com/ManageIQ/manageiq/pull/16824#discussion_r161679886)

Fixes issue caused by fix of https://bugzilla.redhat.com/show_bug.cgi?id=1533277
(Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535189)

## Related to:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/197

