### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm.rb
@@ -53,4 +53,8 @@ class ManageIQ::Providers::Google::CloudManager::Vm < ManageIQ::Providers::Cloud
       "unknown"
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Instance (Google)', 'Instances (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager.rb
+++ b/app/models/manageiq/providers/google/network_manager.rb
@@ -50,4 +50,8 @@ class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::Network
   def description
     ManageIQ::Providers::Google::Regions.find_by_name(provider_region)[:description]
   end
+
+  def self.display_name(number = 1)
+    n_('Network Provider (Google)', 'Network Providers (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/google/network_manager/cloud_network.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::CloudNetwork < ::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (Google)', 'Cloud Networks (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/google/network_manager/cloud_subnet.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::CloudSubnet < ::CloudSubnet
+  def self.display_name(number = 1)
+    n_('Cloud Subnet (Google)', 'Cloud Subnets (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/google/network_manager/floating_ip.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::FloatingIp < ::FloatingIp
+  def self.display_name(number = 1)
+    n_('Floating IP (Google)', 'Floating IPs (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/load_balancer.rb
+++ b/app/models/manageiq/providers/google/network_manager/load_balancer.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::LoadBalancer < ::LoadBalancer
+  def self.display_name(number = 1)
+    n_('Load Balancer (Google)', 'Load Balancers (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/google/network_manager/network_port.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::NetworkPort < ::NetworkPort
+  def self.display_name(number = 1)
+    n_('Network Port (Google)', 'Network Ports (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/google/network_manager/network_router.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::NetworkRouter < ::NetworkRouter
+  def self.display_name(number = 1)
+    n_('Network Router (Google)', 'Network Routers (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/google/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/google/network_manager/security_group.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::NetworkManager::SecurityGroup < ::SecurityGroup
+  def self.display_name(number = 1)
+    n_('Security Group (Google)', 'Security Groups (Google)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836