### PR TITLE
Override az_zone_to_cloud_network method in google prov

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -5,6 +5,12 @@ class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvis
     ems.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
   end
 
+  def availability_zone_to_cloud_network(src)
+    load_ar_obj(src[:ems]).all_cloud_networks.each_with_object({}) do |cn, hash|
+      hash[cn.id] = cn.name
+    end
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')


### PR DESCRIPTION
Per [comment](https://github.com/ManageIQ/manageiq/pull/16824/files#r161679886) we need to override this method in google and openstack because the availability zone to subnet relationship isn't set up yet. 

Fixes issue caused by fix of https://bugzilla.redhat.com/show_bug.cgi?id=1533277
(Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535189)

## Depends on:
https://github.com/ManageIQ/manageiq/pull/16824

## Related to:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/202