### PR TITLE
Test availability_zone_to_cn overriding in google prov

### DIFF
--- a/spec/models/manageiq/providers/google/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/provision_workflow_spec.rb
@@ -1,0 +1,24 @@
+describe ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow do
+  include Spec::Support::WorkflowHelper
+
+  let(:admin) { FactoryGirl.create(:user_with_group) }
+  let(:ems) { FactoryGirl.create(:ems_google) }
+  let(:template) { FactoryGirl.create(:template_google, :name => "template", :ext_management_system => ems) }
+  let(:workflow) do
+    stub_dialog
+    allow(User).to receive_messages(:server_timezone => "UTC")
+    described_class.new({:src_vm_id => template.id}, admin.userid)
+  end
+
+  context "availability_zone_to_cloud_network" do
+    it "has one when it should" do
+      FactoryGirl.create(:cloud_network_google, :ext_management_system => ems.network_manager)
+
+      expect(workflow.allowed_cloud_networks.size).to eq(1)
+    end
+
+    it "has none when it should" do
+      expect(workflow.allowed_cloud_networks.size).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16811 adds RBAC filtering to allowed_cloud_network base class and google needed specs around the fact that the cloud network list is NOT dependent on availability zone choice unlike azure and amazon. (Per https://github.com/ManageIQ/manageiq/pull/16824#discussion_r161679886)

Related bz links: 
https://bugzilla.redhat.com/show_bug.cgi?id=1533277
 https://bugzilla.redhat.com/show_bug.cgi?id=1535189