### PR TITLE
Add back missing IP address range in Virtual Private Cloud name.

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvis
 
   def availability_zone_to_cloud_network(src)
     load_ar_obj(src[:ems]).all_cloud_networks.each_with_object({}) do |cn, hash|
-      hash[cn.id] = cn.name
+      hash[cn.id] = cloud_network_display_name(cn)
     end
   end
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/16898.

https://bugzilla.redhat.com/show_bug.cgi?id=1538696

@miq-bot add_label bug, gaprindashvili/yes