### PR TITLE
Fix API request scheme for preemptible flag when provisioning

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -17,7 +17,9 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
     clone_options[:disks]        = [boot_disk]
     clone_options[:machine_type] = instance_type.ems_ref
     clone_options[:zone_name]    = dest_availability_zone.ems_ref
-    clone_options[:preemptible]  = get_option(:is_preemptible)
+    clone_options[:scheduling]   = {
+      :preemptible => get_option(:is_preemptible)
+    }
 
     if clone_options[:user_data]
       clone_options[:metadata] = {"user-data"          => Base64.encode64(clone_options[:user_data]),

--- a/spec/models/manageiq/providers/google/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/provision_spec.rb
@@ -30,6 +30,17 @@ describe ManageIQ::Providers::Google::CloudManager::Provision do
         expect(subject).to receive(:userdata_payload).and_return(nil)
         expect(subject.prepare_for_clone_task[:metadata]).to eql(nil)
       end
+
+      it "sets preemptible flag" do
+        subject.options = {:is_preemptible => true}
+        clone_options = subject.prepare_for_clone_task
+
+        expect(clone_options).to include(
+          :scheduling => {
+            :preemptible => true
+          }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Adapt to changed API request scheme, so the `:preemptible` flag is sent as:

```
{
  ...
  "scheduling": {
    "preemptible": [true,false]
    ...
  }
  ...
}
```

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1619298