### PR TITLE
rename client's proxy option

### DIFF
--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -29,9 +29,7 @@ module ManageIQ::Providers::Google::ManagerMixin
         :google_json_key_string => MiqPassword.try_decrypt(google_json_key),
         :app_name               => Vmdb::Appliance.PRODUCT_NAME,
         :app_version            => Vmdb::Appliance.VERSION,
-        :google_client_options  => {
-          :proxy => proxy_uri
-        }
+        :google_client_options  => { :proxy_url => proxy_uri },
       }
 
       begin

--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google", ">=1.5.0"
+  s.add_dependency "fog-google", ">= 1.8.1", "< 2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -7,9 +7,7 @@ describe ManageIQ::Providers::Google::CloudManager do
         :google_json_key_string => "encrypted",
         :app_name               => Vmdb::Appliance.PRODUCT_NAME,
         :app_version            => Vmdb::Appliance.VERSION,
-        :google_client_options  => {
-          :proxy => "proxy_uri"
-        }
+        :google_client_options  => { :proxy_url => "proxy_uri" },
       }
     end
 
@@ -93,7 +91,7 @@ describe ManageIQ::Providers::Google::CloudManager do
 
         require 'fog/google'
         expect(Fog::Compute::Google).to receive(:new) do |options|
-          expect(options.fetch_path(:google_client_options, :proxy).to_s)
+          expect(options.fetch_path(:google_client_options, :proxy_url).to_s)
             .to eq("http://my_user:my_password@192.168.24.99:1234")
         end
         @e.connect


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1623862

In a recent `google-api-ruby-client` gem versions option `proxy` now named as `proxy_url`:
https://github.com/googleapis/google-api-ruby-client/blob/8faa43b9f7e6b06cc820df4bcffb384b988e33d1/lib/google/apis/options.rb#L21

This PR align that option name accordingly.

P.S. There is one more PR for that: https://github.com/fog/fog-google/pull/418
but current one can be merged without waiting.