### PR TITLE
Fix deprecation on static attributes

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
   end
 
   factory :ems_google_with_project, :parent => :ems_google_with_authentication, :traits => [:with_zone] do
-    project 'GOOGLE_PROJECT'
+    project { 'GOOGLE_PROJECT' }
   end
 
   trait :with_zone do


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Static attributes will be removed in FactoryBot
5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

project { "GOOGLE_PROJECT" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop
--require rubocop-rspec
--only FactoryBot/AttributeDefinedStatically
--auto-correct