### PR TITLE
update_attributes deprecated

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -7,6 +7,6 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
     with_provider_object(&:destroy)
-    self.update_attributes!(:raw_power_state => "DELETED")
+    self.update!(:raw_power_state => "DELETED")
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -10,6 +10,6 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
 
   def raw_reboot_guest
     with_provider_object(&:reboot)
-    self.update_attributes!(:raw_power_state => "reboot") # show state as suspended
+    self.update!(:raw_power_state => "reboot") # show state as suspended
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
@@ -26,11 +26,11 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Power
 
   def raw_start
     with_provider_object(&:start)
-    self.update_attributes!(:raw_power_state => "starting")
+    self.update!(:raw_power_state => "starting")
   end
 
   def raw_stop
     with_provider_object(&:stop)
-    self.update_attributes!(:raw_power_state => "stopping")
+    self.update!(:raw_power_state => "stopping")
   end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
         :auth_key => service_account,
         :userid   => "_"
       )
-      ems.update_attributes(:project => project)
+      ems.update(:project => project)
     end
   end
 


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.