### PR TITLE
Fix for some networks not having subnets

### DIFF
--- a/app/models/manageiq/providers/google/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/collector/network_manager.rb
@@ -11,8 +11,8 @@ class ManageIQ::Providers::Google::Inventory::Collector::NetworkManager < Manage
       @subnetworks += connection.networks.select { |x| x.ipv4_range.present? }.map do |x|
         Fog::Compute::Google::Subnetwork.new(
           :name               => x.name,
-          :gateway_address    => x.gateway_ipv4,
-          :ip_cidr_range      => x.ipv4_range,
+          :gateway_address    => x.gateway_i_pv4,
+          :ip_cidr_range      => x.i_pv4_range,
           :id                 => x.id,
           :network            => x.self_link,
           :self_link          => x.self_link,

--- a/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
@@ -74,7 +74,7 @@ class ManageIQ::Providers::Google::Inventory::Parser::NetworkManager < ManageIQ:
   # @param network [Fog::Compute::Google::Network]
   def cloud_subnets(persister_cloud_network, network)
     @subnets_by_network_link ||= collector.cloud_subnets.each_with_object({}) { |x, subnets| (subnets[x.network] ||= []) << x }
-    @subnets_by_network_link[network.self_link].each do |cloud_subnet|
+    @subnets_by_network_link[network.self_link]&.each do |cloud_subnet|
       uid = cloud_subnet.id.to_s
       persister.cloud_subnets.build(
         :cidr          => cloud_subnet.ip_cidr_range,


### PR DESCRIPTION
It has been seen that some cloud networks don't have subnets causing
refresh to fail.

This fixes the two issues which were seen.