### PR TITLE
Move raw_ vm operations to providers

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -69,30 +69,4 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   def supports_authentication?(authtype)
     supported_auth_types.include?(authtype.to_s)
   end
-
-  # Operations
-
-  def vm_start(vm, _options = {})
-    vm.start
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
-
-  def vm_stop(vm, _options = {})
-    vm.stop
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
-
-  def vm_destroy(vm, _options = {})
-    vm.vm_destroy
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
-
-  def vm_reboot_guest(vm, _options = {})
-    vm.reboot_guest
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
 end


### PR DESCRIPTION
All of these operations are overridden by the Vm subclass so there is no need to have the "parent" operations defined since run_command_via_parent isn't actually called.

https://github.com/ManageIQ/manageiq/pull/19452