### PR TITLE
Subclass CloudManager metrics capture

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/metrics_capture.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Google::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+class ManageIQ::Providers::Google::CloudManager::MetricsCapture < ManageIQ::Providers::CloudManager::MetricsCapture
   # List of counters we expose to the caller
   VIM_STYLE_COUNTERS = {
     "cpu_usage_rate_average"  => {

--- a/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
@@ -8,6 +8,12 @@ describe ManageIQ::Providers::Google::CloudManager::MetricsCapture do
   before(:all) { Fog.mock! }
   after(:all)  { Fog.unmock! }
 
+  context "#perf_capture_object" do
+    it "returns the correct class" do
+      expect(ems.perf_capture_object.class).to eq(described_class)
+    end
+  end
+
   describe '#perf_collect_metrics' do
     subject { vm.perf_collect_metrics('realtime') }
 


### PR DESCRIPTION
google is a cloud metrics capture class. subclassing the proper parent

part of ManageIQ/manageiq#19684