### PR TITLE
Remove provider_region from DDF validation dependencies

### DIFF
--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Google::ManagerMixin
             :fields    => [
               :component              => 'validate-provider-credentials',
               :name                   => 'endpoints.default.valid',
-              :validationDependencies => %w[zone_name provider_region],
+              :validationDependencies => %w[zone_name],
               :fields                 => [
                 {
                   :component  => "text-field",


### PR DESCRIPTION
There's no region among the fields, so this dependency is unnecessary. Not really a bug. Wrongly copy-pasted in https://github.com/ManageIQ/manageiq-providers-google/pull/120

@miq-bot assign @agrare 