### PR TITLE
Remove bogus partial, update variable name

### DIFF
--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -67,9 +67,9 @@ describe ManageIQ::Providers::Google::CloudManager do
     before do
       @google_project = "yourprojectid"
       @google_json_key = "{\r\n\"type\": \"service_account\",\r\n\"private_key_id\": \"abcdefg\"}"
-      @e = FactoryBot.create(:ems_google)
-      @e.authentications << FactoryBot.create(:authentication, :userid => "_", :auth_key => @google_json_key)
-      @e.project = @google_project
+      @ems = FactoryBot.create(:ems_google)
+      @ems.authentications << FactoryBot.create(:authentication, :userid => "_", :auth_key => @google_json_key)
+      @ems.project = @google_project
     end
 
     context "#connect " do
@@ -78,7 +78,7 @@ describe ManageIQ::Providers::Google::CloudManager do
           expect(project).to eq(@google_project)
           expect(auth_key).to eq(@google_json_key)
         end
-        @e.connect
+        @ems.connect
       end
 
       it "sends proxy uri when set to fog-google" do
@@ -94,14 +94,13 @@ describe ManageIQ::Providers::Google::CloudManager do
           expect(options.fetch_path(:google_client_options, :proxy_url).to_s)
             .to eq("http://my_user:my_password@192.168.24.99:1234")
         end
-        @e.connect
+        @ems.connect
       end
     end
 
     context "#validation" do
       it "handles incorrect password" do
-        allow(ManageIQ::Providers::Google::CloudManager).to receive(:connect).and_raise(StandardError)
-        expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Invalid Google JSON*/)
+        expect { @ems.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Invalid Google JSON*/)
       end
     end
   end


### PR DESCRIPTION
This PR removes an invalid partial from the specs:

`allow(ManageIQ::Providers::Google::CloudManager).to receive(:connect).and_raise(StandardError)`

There is no `connect` singleton method for `ManageIQ::Providers::Google::CloudManager`, only an instance method, which ultimately does call the `raw_connect` singleton method. Removing it had no effect.

The spec passes without this line because the call to `Fog::Compute.new` in manager_mixin.rb fails "naturally" with the already-bogus `google_json_key_string` option, which is then re-raised.

While I was here I updated the non-descriptive `@e` to `@ems`.