### PR TITLE
Lock down fog-google to 1.9.1 to fix vcr

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google", ">= 1.8.1", "< 2.0.0"
+  s.add_dependency "fog-google", "~> 1.9.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Fix VCR spec failures by locking down to 1.9.1