### PR TITLE
Catch errors listing load_balancer health_members

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
@@ -350,7 +350,7 @@ class ManageIQ::Providers::Google::Inventory::Parser::NetworkManager < ManageIQ:
         :status_reason              => ""
       )
     end
-  rescue Fog::Errors::Error => err
+  rescue Fog::Errors::Error, Google::Apis::ClientError => err
     _log.warn("Caught unexpected error when probing health for target pool #{target_pool.name}: #{err}")
     _log.warn(err.backtrace.join("\n"))
     return []


### PR DESCRIPTION
It is possible for a load_balancer member to be present but not
accessible with the credentials provided by the user.  If this is the
case the `target_pool.get_health` call raises an exception which causes
the refresh to fail:
```
[Google::Apis::ClientError]: notFound: The resource 'projects/oceanic-guard-191815/zones/us-central1-c/instances/ja15gc-hv6kc-m-2' was not found
```

We can catch this exception and continue the refresh just skipping that
one load balancer's health members.

Fixes https://github.com/ManageIQ/manageiq-providers-google/issues/130