### PR TITLE
[WIP] Google::NetworkManager belongs to a parent manager

### DIFF
--- a/app/models/manageiq/providers/google/network_manager.rb
+++ b/app/models/manageiq/providers/google/network_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::Network
   require_nested :Refresher
   require_nested :SecurityGroup
 
+  include BelongsToParentManagerMixin
   include ManageIQ::Providers::Google::ManagerMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20229
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136