### PR TITLE
Set the Google::Apis.logger so it doesn't default to Rails.logger

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,2 +1,4 @@
-# GlobalVars:
-#   AllowedVariables:
+GlobalVars:
+  AllowedVariables:
+  # Loggers
+  - $gce_log

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -77,6 +77,9 @@ module ManageIQ::Providers::Google::ManagerMixin
     end
 
     def raw_connect(google_project, google_json_key, options, proxy_uri = nil, validate = false)
+      require "google/apis"
+      ::Google::Apis.logger = $gce_log
+
       require 'fog/google'
 
       config = {


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20235

Fixes https://github.com/ManageIQ/manageiq-providers-google/issues/140