### PR TITLE
Don't fill the logs with backtraces for common errors

### DIFF
--- a/app/models/manageiq/providers/google/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/collector/network_manager.rb
@@ -149,10 +149,8 @@ class ManageIQ::Providers::Google::Inventory::Collector::NetworkManager < Manage
 
     begin
       @vm_cache.store_path(zone, instance, connection.get_server(instance, zone).id)
-    rescue Fog::Errors::Error, ::Google::Apis::ClientError => err
-      m = "Error during data collection for [#{manager&.name}] id: [#{manager&.id}] when querying link for vm_id: #{err}"
-      _log.warn(m)
-      _log.warn(err.backtrace.join("\n"))
+    rescue Fog::Errors::Error, ::Google::Apis::ClientError => _err
+      # It is common for load balancers to have "stale" servers defined which fail when queried
       nil
     end
   end
@@ -163,10 +161,8 @@ class ManageIQ::Providers::Google::Inventory::Collector::NetworkManager < Manage
     return @health_check_cache.fetch_path(health_check) if @health_check_cache.has_key_path?(health_check)
 
     @health_check_cache.store_path(health_check, connection.http_health_checks.get(health_check))
-  rescue Fog::Errors::Error => err
-    m = "Error during data collection for [#{manager&.name}] id: [#{manager&.id}] when querying link for health check: #{err}"
-    _log.warn(m)
-    _log.warn(err.backtrace.join("\n"))
+  rescue Fog::Errors::Error, ::Google::Apis::ClientError => _err
+    # It is common for load balancers to have "stale" servers defined which fail when queried
     nil
   end
 end

--- a/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
@@ -350,9 +350,8 @@ class ManageIQ::Providers::Google::Inventory::Parser::NetworkManager < ManageIQ:
         :status_reason              => ""
       )
     end
-  rescue Fog::Errors::Error, Google::Apis::ClientError => err
-    _log.warn("Caught unexpected error when probing health for target pool #{target_pool.name}: #{err}")
-    _log.warn(err.backtrace.join("\n"))
+  rescue Fog::Errors::Error, Google::Apis::ClientError => _err
+    # It is common for load balancers to have "stale" servers defined which fail when queried
     return []
   end
   #


### PR DESCRIPTION
There are a number of errors around load balancers that are common
because when VMs are deleted they aren't removed from the LBs.

This leads to a huge number of exceptions and long backtraces printed to
the logs.

Example:
```
[----] W, [2020-06-02T14:44:27.547481 #586844:9de4]  WARN -- : MIQ(ManageIQ::Providers::Google::Inventory::Parser::NetworkManager#load_balancer_health_check_members) Caught unexpected error when probing health for target pool a1f056966dee741909b0aa9429805892: notFound: The         resource 'projects/oceanic-guard-191815/zones/us-central1-c/instances/sert-g-ndvkn-m-2' was not found
[----] W, [2020-06-02T14:44:27.547771 #586844:9de4]  WARN -- : MIQ(ManageIQ::Providers::Google::Inventory::Parser::NetworkManager#load_balancer_health_check_members) /home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:218:in              `check_status'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/api_command.rb:116:in `check_status'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:183:in `process_response'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:299:in `execute_once'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:104:in `block (2 levels) in execute'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `times'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `retriable'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:101:in `block in execute'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `times'
/home/grare/adam/.gems/2.7.0/gems/retriable-3.1.2/lib/retriable.rb:56:in `retriable'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/http_command.rb:93:in `execute'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/lib/google/apis/core/base_service.rb:360:in `execute_or_queue_command'
/home/grare/adam/.gems/2.7.0/gems/google-api-client-0.23.9/generated/google/apis/compute_v1/service.rb:17808:in `get_target_pool_health'
/home/grare/adam/src/manageiq/fog-google/lib/fog/compute/google/requests/get_target_pool_health.rb:12:in `get_target_pool_health'
/home/grare/adam/src/manageiq/fog-google/lib/fog/compute/google/models/target_pool.rb:121:in `block in get_health'
/home/grare/adam/src/manageiq/fog-google/lib/fog/compute/google/models/target_pool.rb:118:in `map'
/home/grare/adam/src/manageiq/fog-google/lib/fog/compute/google/models/target_pool.rb:118:in `get_health'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:328:in `load_balancer_health_check_members'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:42:in `block (3 levels) in parse'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:315:in `block in load_balancer_health_check'
/usr/lib/ruby/2.7.0/set.rb:328:in `each_key'
/usr/lib/ruby/2.7.0/set.rb:328:in `each'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:292:in `load_balancer_health_check'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:41:in `block (2 levels) in parse'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:255:in `block in load_balancer_pools'
/home/grare/adam/.gems/2.7.0/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `each'
/home/grare/adam/.gems/2.7.0/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `each'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:247:in `load_balancer_pools'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:38:in `block in parse'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:212:in `load_balancers'
/home/grare/adam/src/manageiq/manageiq-providers-google/app/models/manageiq/providers/google/inventory/parser/network_manager.rb:37:in `parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:42:in `block in parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in `each'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in `parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:125:in `parse_targeted_inventory'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:92:in `block in refresh_targets_for_ems'
/home/grare/adam/.gems/2.7.0/bundler/gems/manageiq-gems-pending-d5a92a93e24d/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/grare/adam/.gems/2.7.0/bundler/gems/manageiq-gems-pending-d5a92a93e24d/lib/gems/pending/util/extensions/miq-benchmark.rb:28:in `realtime_block'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:91:in `refresh_targets_for_ems'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:41:in `block (2 levels) in refresh'
/home/grare/adam/.gems/2.7.0/bundler/gems/manageiq-gems-pending-d5a92a93e24d/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/grare/adam/.gems/2.7.0/bundler/gems/manageiq-gems-pending-d5a92a93e24d/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:41:in `block in refresh'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:31:in `each'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:31:in `refresh'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:11:in `refresh'
/home/grare/adam/src/manageiq/manageiq/app/models/ems_refresh.rb:93:in `block in refresh'
/home/grare/adam/src/manageiq/manageiq/app/models/ems_refresh.rb:92:in `each'
/home/grare/adam/src/manageiq/manageiq/app/models/ems_refresh.rb:92:in `refresh'
```