### PR TITLE
Log exceptions unless they are the common notFound errors

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/parser/network_manager.rb
@@ -350,8 +350,9 @@ class ManageIQ::Providers::Google::Inventory::Parser::NetworkManager < ManageIQ:
         :status_reason              => ""
       )
     end
-  rescue Fog::Errors::Error, Google::Apis::ClientError => _err
+  rescue Fog::Errors::Error, Google::Apis::ClientError => err
     # It is common for load balancers to have "stale" servers defined which fail when queried
+    _log.warn("Unexpected error when probing health for target pool #{target_pool.name}: #{err}") unless err.message.start_with?("notFound: ")
     return []
   end
   #


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-providers-google/pull/142 which didn't log any exceptions rather than just the "expected" ones