### PR TITLE
Fix provisioned instances not getting external IPs

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -21,6 +21,10 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
       :preemptible => get_option(:is_preemptible)
     }
 
+    clone_options[:network_interfaces] = [
+      {:access_configs => [{:name => "External NAT", :type => "ONE_TO_ONE_NAT"}]}
+    ]
+
     if clone_options[:user_data]
       clone_options[:metadata] = {
         :items => [


### PR DESCRIPTION
For instances to pull an ephemeral ip address we have to provide access_config for the network_interfaces