### PR TITLE
Mark the event monitor running before first event

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -13,8 +13,8 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
   # #stop_event_monitor is called.
   def monitor_events
     _log.info "#{log_prefix} Monitoring for events"
+    event_monitor_running
     event_monitor_handle.each_batch do |events|
-      event_monitor_running
       _log.debug "#{log_prefix} Received events #{events.collect { |e| parse_event_type(e) }}"
       @queue.enq events
       sleep_poll_normal


### PR DESCRIPTION
If we don't mark the event_monitor thread as running before the first event is delivered then the worker doesn't heartbeat and also won't shutdown cleanly.

Related to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/633