### PR TITLE
Link up GCE Events to the relevant VMs

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
@@ -17,6 +17,12 @@ module ManageIQ::Providers::Google::CloudManager::EventParser
       :ems_id     => ems_id
     }
 
+    resource = event.dig("jsonPayload", "resource") || {}
+    if resource["type"] == "instance"
+      event_hash[:vm_ems_ref] = resource["id"]
+      event_hash[:vm_uid_ems] = resource["id"]
+    end
+
     event_hash
   end
 end

--- a/spec/models/manageiq/providers/google/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/event_parser_spec.rb
@@ -11,7 +11,8 @@ describe ManageIQ::Providers::Google::CloudManager::EventParser do
           :message    => event_type,
           :timestamp  => "2018-05-21T13:36:40.472279Z",
           :full_data  => event_json,
-          :ems_id     => nil
+          :ems_id     => nil,
+          :vm_ems_ref => event_json.fetch_path("jsonPayload", "resource", "id")
         )
       end
     end


### PR DESCRIPTION
The GCE event parser never attempted to link up events with their resources.  For instances the ems_ref is stored in resource.id if the resource.type is "instance"