### PR TITLE
update fog for faraday

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "fog-google", "~> 1.9"
+  s.add_dependency "fog-google", "~> 1.10"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
need to update this for faraday: 
```
Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    manageiq-providers-google was resolved to 0.1.0, which depends on
      fog-google (~> 1.9.1) was resolved to 1.9.1, which depends on
        google-api-client (~> 0.23.0) was resolved to 0.23.9, which depends on
          googleauth (>= 0.5, < 0.7.0) was resolved to 0.5.1, which depends on
            faraday (~> 0.9)
    manageiq-api-client was resolved to 0.3.5, which depends on
      faraday (~> 1.0.0)
```