### PR TITLE
require a minimum googleauth for faraday 1.0

### DIFF
--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fog-google", "~> 1.10"
+  spec.add_dependency "googleauth", "~> 0.11.0"
 
   spec.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
we need an updated googleauth:

```
    manageiq-providers-google was resolved to 0.1.0, which depends on
      fog-google (~> 1.10) was resolved to 1.11.0, which depends on
        google-api-client (>= 0.32, < 0.34) was resolved to 0.32.1, which depends on
          googleauth (>= 0.5, < 0.10.0) was resolved to 0.5.1, which depends on
            memoist (~> 0.12)
```

` googleauth (>= 0.5, < 0.10.0) was resolved to 0.5.1` isn't going to let us upgrade

https://rubygems.org/gems/googleauth/versions/0.11.0 is the first one with `faraday >= 0.17.3, < 2.0`

from issue 3089 on bundler, "It is literally impossible to guarantee that you will always get the newest possible version without exhaustively checking every possible combination of versions, which could potentially take as long as infinity time. We avoid that, but a side effect is sometimes picking versions that are lower than versions that would be acceptable."

"If you actually care about the versions that you get, you must specify them in the Gemfile." 

