### PR TITLE
Add dummy DDF schema for CloudVolume editing

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
 
   include ManageIQ::Providers::Google::ManagerMixin
 
+  supports :cloud_volume
   supports :provisioning
 
   before_create :ensure_managers

--- a/app/models/manageiq/providers/google/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/cloud_volume.rb
@@ -1,2 +1,7 @@
 class ManageIQ::Providers::Google::CloudManager::CloudVolume < ::CloudVolume
+  def self.params_for_create(_)
+    {
+      :fields => []
+    }
+  end
 end


### PR DESCRIPTION
We cannot create cloud volumes for this provider, but it's possible to edit them names of existing ones. Therefore, it is necessary to have an empty DDF schema that makes the API request building the additional DDF fields pass.

I also had to mark the provider with `supports :cloud_volume` but not with `supports :cloud_volume_create` to make the UI able to query this information via the API.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7334

@miq-bot assign @agrare 
@miq-bot add_label enhancement