### PR TITLE
Fix linter warnings - unused variable, ineffective access modifier

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
-  def do_clone_task_check(clone_task_ref)
+  def do_clone_task_check(_clone_task_ref)
     source.with_provider_connection(:service => 'compute') do |google|
       instance = google.servers.get(dest_name, dest_availability_zone.ems_ref)
 

--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -11,13 +11,13 @@ class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvis
     end
   end
 
+  def self.provider_model
+    ManageIQ::Providers::Google::CloudManager
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
     super(message, {'platform' => 'google'})
-  end
-
-  def self.provider_model
-    ManageIQ::Providers::Google::CloudManager
   end
 end


### PR DESCRIPTION
This PR fixes two linter warnings that rubocop found. First, it underscores an unused argument to the `do_clone_task_check` method. Second, it moves the `provider_model` singleton method out of the private block since it had no effect, and isn't meant to be private anyway.