### PR TITLE
Convert `supports_#{op}?` to `supports?(op)`

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/template.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Google::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations
 
   included do
     supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
     end
   end
 

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
 
   included do
     supports :reboot_guest do
-      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
       unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
     end
   end

--- a/spec/models/manageiq/providers/google/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/vm_spec.rb
@@ -32,10 +32,10 @@ describe ManageIQ::Providers::Google::CloudManager::Vm do
     end
   end
 
-  describe "#supports_terminate?" do
+  describe "#supports?(:terminate)" do
     context "when connected to a provider" do
       it "returns true" do
-        expect(vm.supports_terminate?).to be_truthy
+        expect(vm.supports?(:terminate)).to be_truthy
       end
     end
 
@@ -43,7 +43,7 @@ describe ManageIQ::Providers::Google::CloudManager::Vm do
       let(:archived_vm) { FactoryBot.create(:vm_google) }
 
       it "returns false" do
-        expect(archived_vm.supports_terminate?).to be_falsey
+        expect(archived_vm.supports?(:terminate)).to be_falsey
         expect(archived_vm.unsupported_reason(:terminate)).to eq("The VM is not connected to an active Provider")
       end
     end


### PR DESCRIPTION
Additionally, convert method definitions such as

```ruby
def supports_port?
  true
end
```

to

```ruby
supports :port
```