### PR TITLE
Don't collect unused images

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -151,7 +151,7 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
   end
 
   def images
-    collector.images.reject(&method(:skip_image?)).each do |image|
+    collector.images.select { |img| active_image?(img) }.each do |image|
       persister_miq_template = image(image)
 
       image_os(persister_miq_template, image)
@@ -727,11 +727,7 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
     image.kind == "compute#image" ? !image.deprecated.nil? : false
   end
 
-  def skip_image?(image)
-    return false if options.get_deprecated_images
-    return false if !deprecated_image?(image)
-    return false if @active_images.include?(image.id.to_s)
-
-    true
+  def active_image?(image)
+    !deprecated_image?(image) || @active_images.include?(image.id.to_s) || options.get_deprecated_images
   end
 end

--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -38,6 +38,8 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
     cloud_database_flavors
     cloud_volumes
     cloud_volume_snapshots
+
+    # Instances has to be called first in order to set the `@active_images`
     instances
     images
 

--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -727,7 +727,7 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
 
   def skip_image?(image)
     return false if options.get_deprecated_images
-    return false unless deprecated_image?(image)
+    return false if !deprecated_image?(image)
     return false if @active_images.include?(image.id.to_s)
 
     true

--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -9,10 +9,6 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
     "UNHEALTHY" => "OutOfService"
   }.freeze
 
-  def options
-    @options ||= Settings.ems_refresh[persister.manager.class.ems_type]
-  end
-
   def initialize
     super
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@
       :event_groups:
 :ems_refresh:
   :gce:
+    :get_deprecated_images: false
     :inventory_collections:
       :saver_strategy: default
   :gce_network:

--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -91,13 +91,12 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :load_balancer_listener_pool       => 4,
       :load_balancer_pool_member         => 3,
       :load_balancer_pool_member_pool    => 4,
-      :miq_template                      => 1511, # 1510 (images) + 1 (cloud_volume_snapshots)
+      :miq_template                      => 113,
       :network                           => 0,
       :network_port                      => 15,
       :network_port_security_group       => 15,
       :network_router                    => 0,
-      :operating_system                  => 1526, # 1510 (images) + 1 (cloud_volume_snapshots) + 15 (instances)
-      # :operating_system                  => 1523, # in old refresh (OS skipped for instances with instance.image.nil?)
+      :operating_system                  => 128,
       :orchestration_stack               => 0,
       :orchestration_stack_output        => 0,
       :orchestration_stack_parameter     => 0,
@@ -107,7 +106,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :resource_group                    => 0,
       :security_group                    => 3,
       :vm                                => 15,
-      :vm_or_template                    => 1526, # :miq_template + :vm
+      :vm_or_template                    => 128, # :miq_template + :vm
     }
   end
 


### PR DESCRIPTION
If an image is deprecated it can't be selected for provisioning new
instances, and if it isn't connected to any active instances then it is
serving no purpose being saved to the database.

Depends on ManageIQ/manageiq#21460

Fixes https://github.com/ManageIQ/manageiq-providers-google/issues/198