### PR TITLE
Fix `#has_credentials?` and `#missing_credentials?`

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -64,12 +64,11 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     {"google" => N_("Google")}
   end
 
-  # TODO(lwander) determine if user wants to use OAUTH or a service account
-  def missing_credentials?(_type = {})
-    false
-  end
-
   def supports_authentication?(authtype)
     supported_auth_types.include?(authtype.to_s)
+  end
+
+  def required_credential_fields(_type)
+    [:auth_key]
   end
 end

--- a/spec/models/manageiq/providers/google/cloud_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/event_catcher/stream_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream do
 
   let(:ems)               { FactoryBot.create(:ems_google_with_project) }
   let(:subscription)      { Fog::Google::Pubsub::Subscription.new }
-  let(:pubsub_connection) { ems.connect(:service => 'pubsub') }
+  let(:pubsub_connection) { ::Fog::Google::Pubsub.new(:google_project => ems.project) }
   let(:stream)            { described_class.new(ems) }
   let(:subscription_name) { "projects/GOOGLE_PROJECT/subscriptions/manageiq-eventcatcher-#{ems.guid}" }
 

--- a/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
@@ -2,7 +2,7 @@ describe ManageIQ::Providers::Google::CloudManager::MetricsCapture do
   require 'fog/google'
 
   let(:ems)                   { FactoryBot.create(:ems_google_with_project) }
-  let(:metrics_connection)    { ems.connect(:service => 'monitoring') }
+  let(:metrics_connection)    { ::Fog::Google::Monitoring.new(:google_project => ems.project) }
   let(:timeseries_collection) { double }
 
   before(:all) { Fog.mock! }


### PR DESCRIPTION
GCE uses an AuthToken type authentication which means that the `required_credential_fields` should be `:auth_key` not `:userid`

This was causing `gce.vms.first.refresh_ems` to raise `RuntimeError (No Provider credentials defined)` in all cases.

`gce.refresh_ems` was working because that uses `#missing_credentials?` which was hard-coded to `false` here (fixed).