### PR TITLE
[MORPHY] Allow miq_workers rows of this type to be instantiated for destroy

### DIFF
--- a/app/models/manageiq/providers/google/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/google/network_manager/refresh_worker.rb
@@ -1,2 +1,6 @@
-class ManageIQ::Providers::Google::NetworkManager::RefreshWorker
+class ManageIQ::Providers::Google::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
+end
+
+# We need a subclass of this refresh worker to avoid it from being a leaf class and seeded as a MiqWorkerType.
+class ManageIQ::Providers::Google::NetworkManager::RefreshWorkerBogusChild < ManageIQ::Providers::Google::NetworkManager::RefreshWorker
 end

--- a/spec/models/manageiq/providers/google/network_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/google/network_manager/refresh_worker_spec.rb
@@ -1,0 +1,13 @@
+describe ManageIQ::Providers::Google::NetworkManager::RefreshWorker do
+  context "stub" do
+    it "won't be seeded" do
+      MiqWorkerType.seed
+      expect(MiqWorkerType.where(:worker_type => described_class.name).count).to eq 0
+    end
+
+    it "allows existing rows of this type to be instantiated" do
+      FactoryBot.create(:miq_worker, :type => described_class)
+      expect(MiqWorker.first.type).to eq(described_class.name)
+    end
+  end
+end


### PR DESCRIPTION
Avoid MiqWorkerType seeding by making the stub refresh worker class NOT a leaf
class.

Note, https://github.com/ManageIQ/manageiq-providers-google/pull/197 has this:

> For backport I'll include a stub RefreshWorker class that doesn't inherit from MiqWorker (so it won't be seeded) but should prevent issues if there are any workers of this type

I tried to solve this by making a bogus subclass of the refresh worker so the refresh worker wouldn't be seeded in miq_worker_types.  I'm not sure if this hack is worse off than letting the type be seeded.  cc @agrare 