### PR TITLE
ContainerVolume cannot be subclassed currently

### DIFF
--- a/app/models/manageiq/providers/google/container_manager.rb
+++ b/app/models/manageiq/providers/google/container_manager.rb
@@ -5,7 +5,6 @@ class ManageIQ::Providers::Google::ContainerManager < ManageIQ::Providers::Kuber
   require_nested :ContainerGroup
   require_nested :ContainerNode
   require_nested :ContainerTemplate
-  require_nested :ContainerVolume
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Refresher

--- a/app/models/manageiq/providers/google/container_manager/container_volume.rb
+++ b/app/models/manageiq/providers/google/container_manager/container_volume.rb
@@ -1,4 +1,0 @@
-ManageIQ::Providers::Kubernetes::ContainerManager::ContainerVolume.include(ActsAsStiLeafClass)
-
-class ManageIQ::Providers::Google::ContainerManager::ContainerVolume < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerVolume
-end


### PR DESCRIPTION
ContainerVolume cannot be subclassed currently as there are a number of places which explicitly look for :type => ContainerVolume
