### PR TITLE
Set proxy_uri for Faraday connection

### DIFF
--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -96,6 +96,11 @@ module ManageIQ::Providers::Google::ManagerMixin
         :google_client_options  => { :proxy_url => proxy_uri },
       }
 
+      if proxy_uri
+        require "faraday"
+        Faraday.default_connection_options.proxy = proxy_uri
+      end
+
       begin
         case options[:service]
           # specify Compute as the default


### PR DESCRIPTION
When the user has configured a proxy we send this to fog-google via the google_client_options.  This ends up being set on the google-api-client instance which issues the bulk of the API calls to e.g. collect instances.

There is a second google gem however, `googleauth` which is responsible for (in our case) fetching an access_token for the specified service account before running any other API calls.

When all outbound internet traffic is dropped and everything must go through a proxy this causes this initial call to get an access token to fail.

The googleauth library can use a pre-configured Faraday connection if it is available, and we can setup the proxy on this connection, per https://github.com/googleapis/google-auth-library-ruby/issues/131#issuecomment-446821072