### PR TITLE
Check Pub/Sub service before starting EventCatcher

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -22,6 +22,9 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   supports :catalog
   supports :cloud_volume
   supports :create
+  supports :events do
+    unsupported_reason_add(:events, _("Pub/Sub service is not enabled in this project")) unless capabilities["pubsub"]
+  end
   supports :metrics
   supports :provisioning
 

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
@@ -4,6 +4,6 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher < ManageIQ::Provid
   def self.all_valid_ems_in_zone
     # Only valid to start an EventCatcher if the Pub/Sub service is enabled
     # on the project
-    super.select { |ems| ems.capabilities["pubsub"] }
+    super.select { |ems| ems.supports?(:events) }
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
@@ -1,3 +1,9 @@
 class ManageIQ::Providers::Google::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+
+  def self.all_valid_ems_in_zone
+    # Only valid to start an EventCatcher if the Pub/Sub service is enabled
+    # on the project
+    super.select { |ems| ems.capabilities["pubsub"] }
+  end
 end

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -5,6 +5,10 @@ module ManageIQ::Providers::Google::ManagerMixin
     options[:auth_type] = auth_type
     connect(options, true)
 
+    capabilities["pubsub"] = verify_pubsub_credentials(options)
+
+    save! if changed?
+
     true
   end
 
@@ -17,6 +21,15 @@ module ManageIQ::Providers::Google::ManagerMixin
 
   def gce
     @gce ||= connect(:service => "compute")
+  end
+
+  private
+
+  def verify_pubsub_credentials(options = {})
+    !!connect(options.merge(:service => "pubsub")).subscriptions.all
+  rescue Google::Apis::ClientError
+    # If the Pub/Sub service isn't enabled on this project we cannot collect events
+    false
   end
 
   module ClassMethods

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -112,4 +112,24 @@ describe ManageIQ::Providers::Google::CloudManager do
       expect(ems.catalog_types).to include("google")
     end
   end
+
+  describe "#supports_events?" do
+    let(:ems) { FactoryBot.create(:ems_google, :capabilities => {"pubsub" => pubsub}) }
+
+    context "with pubsub available" do
+      let(:pubsub) { true }
+
+      it "returns true" do
+        expect(ems.supports?(:events)).to be_truthy
+      end
+    end
+
+    context "with pubsub unavailable" do
+      let(:pubsub) { false }
+
+      it "returns falsey" do
+        expect(ems.supports?(:events)).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently we check the Pub/Sub service in the EventCatcher::Stream main `events` loop which runs quite frequently.
This leads to numerous backtraces like this in the log every minute:
```
ERROR -- evm: MIQ(ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner#start_event_monitor) EMS [] as [] Event Monitor Thread aborted because [PERMISSION_DENIED: Cloud Pub/Sub API has not been used in project 1083267972192 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/pubsub.googleapis.com/overview?project=1083267972192 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.]
ERROR -- evm: [Google::Apis::ClientError]: PERMISSION_DENIED: Cloud Pub/Sub API has not been used in project 1083267972192 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/pubsub.googleapis.com/overview?project=1083267972192 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.  Method:[block (2 levels) in <class:LogProxy>]
ERROR -- evm: /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:228:in `check_status'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/api_command.rb:119:in `check_status'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:194:in `process_response'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:310:in `execute_once'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:113:in `block (2 levels) in execute'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:56:in `times'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:56:in `retriable'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:110:in `block in execute'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:56:in `times'
  /opt/manageiq/manageiq-gemset/gems/retriable-3.1.2/lib/retriable.rb:56:in `retriable'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:102:in `execute'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/lib/google/apis/core/base_service.rb:366:in `execute_or_queue_command'
  /opt/manageiq/manageiq-gemset/gems/google-api-client-0.50.0/generated/google/apis/pubsub_v1/service.rb:546:in `get_subscription'
  /opt/manageiq/manageiq-gemset/gems/fog-google-1.15.0/lib/fog/google/requests/pubsub/get_subscription.rb:10:in `get_subscription'
  /opt/manageiq/manageiq-gemset/gems/fog-google-1.15.0/lib/fog/google/models/pubsub/subscriptions.rb:24:in `get'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-google-481bc4aae4f2/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb:58:in `get_or_create_subscription'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-google-481bc4aae4f2/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb:41:in `block in events'
  /var/www/miq/vmdb/app/models/ext_management_system.rb:606:in `with_provider_connection'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-google-481bc4aae4f2/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb:40:in `events'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-google-481bc4aae4f2/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb:26:in `each_batch'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-google-481bc4aae4f2/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb:17:in `monitor_events'
  /var/www/miq/vmdb/app/models/manageiq/providers/base_manager/event_catcher/runner.rb:156:in `block in start_event_monitor'
```

If we check the pubsub service during the scheduled verify_credentials check then we can use the capabilities column to track if we are able to start the event_catcher without having to do any live API calls from the MiqServer monitor_workers loop.