### PR TITLE
introduce snapshot supports :create

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/cloud_volume_snapshot.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Google::CloudManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
+  supports :create
+  supports :update
+  supports :delete
 end


### PR DESCRIPTION
Amazon and openstack, the only other two providers that define cloud volume snapshots, have `supports :CUD` defined.
Updating google to have the same.

This is from https://github.com/ManageIQ/manageiq-api/pull/1134
Though that PR currently does not require this change.