### PR TITLE
Fix cloud_subnet nil refresh error

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -443,6 +443,7 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
 
     # For legacy GCE networks without subnets, we also try a network link
     cloud_subnet = subnets_by_link[network_port[:subnetwork]] || subnets_by_link[network_port[:network]]
+    return if cloud_subnet.nil?
 
     persister.cloud_subnet_network_ports.build(
       :cloud_subnet => persister.cloud_subnets.lazy_find(cloud_subnet.id.to_s),


### PR DESCRIPTION
If a network port doesn't have an associated cloud subnet then cloud_subnet.id will fail with an undefined method error.

Fixes https://github.com/ManageIQ/manageiq-providers-google/issues/218