### PR TITLE
Fix refresh firewall with nil allowed

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -499,7 +499,7 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
       name = firewall.name
       source_ip_range = firewall.source_ranges.nil? ? "0.0.0.0/0" : firewall.source_ranges.first
 
-      firewall.allowed.each do |fw_allowed|
+      firewall.allowed&.each do |fw_allowed|
         protocol      = fw_allowed[:ip_protocol].upcase
         allowed_ports = fw_allowed[:ports].to_a.first
 


### PR DESCRIPTION
If a firewall object has a `nil` set of allowed rules the refresh will fail.

```
manageiq[3626]: ERROR -- evm: MIQ(ManageIQ::Providers::Google::CloudManager::Refresher#refresh) EMS: [gcp], id: [1000000000024] Refresh failed
manageiq[3626]: ERROR -- evm: [NoMethodError]: undefined method 'each' for nil:NilClass Method:[block (2 levels) in <class:LogProxy>]
manageiq[3626]: ERROR -- evm: manageiq-providers-google-b49174958574/app/models/manageiq/providers/google/inventory/parser.rb:501:in `block in firewall_rules'
```