### PR TITLE
Fix LoadBalancer status if instance_health is empty

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -671,16 +671,8 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
 
       # Lookup our health state in the health status map; default to
       # "OutOfService" if we can't find a mapping.
-      status = "OutOfService"
-      unless instance_health.nil?
-        gcp_status = instance_health[0][:health_state]
-
-        if GCP_HEALTH_STATUS_MAP.include?(gcp_status)
-          status = GCP_HEALTH_STATUS_MAP[gcp_status]
-        else
-          _log.warn("Unable to find an explicit health status mapping for state: #{gcp_status} - defaulting to 'OutOfService'")
-        end
-      end
+      health_state = instance_health&.first&.dig(:health_state)
+      status       = GCP_HEALTH_STATUS_MAP[health_state] || "OutOfService"
 
       persister.load_balancer_health_check_members.build(
         :load_balancer_health_check => persister_lb_health_check,


### PR DESCRIPTION
We were only checking if instance_health was `nil` which allowed `[][0][:health_state]` to be run and fail.

```
[NoMethodError]: undefined method `[]' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]"}
{"@timestamp":"2022-05-18T16:15:01.889107 ","hostname":"1-google-cloud-refresh-7-855ffc8896-qqhz9","pid":7,"tid":"9524","service":"evm","level":"err","message":"/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:676:in `block in load_balancer_health_check_members'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:667:in `each'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:667:in `collect'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:667:in `load_balancer_health_check_members'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:654:in `block in load_balancer_health_check'
/usr/share/ruby/set.rb:328:in `each_key'
/usr/share/ruby/set.rb:328:in `each'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:632:in `load_balancer_health_check'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-426282e209bf/app/models/manageiq/providers/google/inventory/parser.rb:592:in `block in load_balancer_pools'
```