### PR TITLE
Add option to expose an instance to External NAT

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -21,9 +21,8 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
       :preemptible => get_option(:is_preemptible)
     }
 
-    clone_options[:network_interfaces] = [
-      {:access_configs => [{:name => "External NAT", :type => "ONE_TO_ONE_NAT"}]}
-    ]
+    clone_options[:network_interfaces] = []
+    clone_options[:network_interfaces] << {:access_configs => [{:name => "External NAT", :type => "ONE_TO_ONE_NAT"}]} if get_option(:public_network)
 
     if clone_options[:user_data]
       clone_options[:metadata] = {


### PR DESCRIPTION
Check the public_network option before exposing an instance to External NAT

No external IP:
![Screenshot from 2022-07-28 13-25-05](https://user-images.githubusercontent.com/12851112/181601501-80452cc3-589a-4b76-b8ce-8f5ced98d9a9.png)

Depends on:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8388
- [x] https://github.com/ManageIQ/manageiq/pull/22020

Closes https://github.com/ManageIQ/manageiq-providers-google/issues/231