### PR TITLE
Refactor cloud network factory from core

### DIFF
--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_network_google,
+          :class  => "ManageIQ::Providers::Google::NetworkManager::CloudNetwork",
+          :parent => :cloud_network
+end


### PR DESCRIPTION
- part of the effort to move provider-specific code out of core repositories

@miq-bot add_labels refactoring, test
@miq-bot assign @agrare 