### PR TITLE
Fix NoMethodError .split for NilClass

### DIFF
--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -710,6 +710,8 @@ class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inve
   end
 
   def parse_uid_from_url(url)
+    return if url.nil?
+
     # A lot of attributes in gce are full URLs with the
     # uid being the last component.  This helper method
     # returns the last component of the url


### PR DESCRIPTION
Regional cloud volumes do not have a zone_id and were causing an undefined method .split for nil:NilClass failure during the refresh.

```
[----] E, [2022-10-18T09:26:39.452196 #1972020:8d7c] ERROR -- evm: MIQ(ManageIQ::Providers::google::CloudManager::Refresher#refresh) EMS: [gce], id: [1000000000033] Refresh failed
[----] E, [2022-10-18T09:26:39.453004 #1972020:8d7c] ERROR -- evm: [NoMethodError]: undefined method `split' for nil:NilClass Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2022-10-18T09:26:39.453129 #1972020:8d7c] ERROR -- evm: /opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-f84430665b2a/app/models/manageiq/providers/google/inventory/parser.rb:716:in `parse_uid_from_url'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-f84430665b2a/app/models/manageiq/providers/google/inventory/parser.rb:115:in `block in cloud_volumes'
/opt/IBM/infrastructure-management-gemset/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `each'
/opt/IBM/infrastructure-management-gemset/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `each'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-f84430665b2a/app/models/manageiq/providers/google/inventory/parser.rb:114:in `cloud_volumes'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-google-f84430665b2a/app/models/manageiq/providers/google/inventory/parser.rb:39:in `parse'
```