### PR TITLE
Delegate NetworkManager#refresh to CloudManager

### DIFF
--- a/app/models/manageiq/providers/google/network_manager.rb
+++ b/app/models/manageiq/providers/google/network_manager.rb
@@ -9,7 +9,6 @@ class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::Network
   require_nested :LoadBalancerPoolMember
   require_nested :NetworkPort
   require_nested :NetworkRouter
-  require_nested :Refresher
   require_nested :SecurityGroup
 
   include ManageIQ::Providers::Google::ManagerMixin
@@ -30,6 +29,8 @@ class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::Network
            :default_endpoint,
            :endpoints,
            :google_tenant_id,
+           :refresh,
+           :refresh_ems,
            :to        => :parent_manager,
            :allow_nil => true
 

--- a/app/models/manageiq/providers/google/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/google/network_manager/refresher.rb
@@ -1,7 +1,0 @@
-module ManageIQ::Providers
-  class Google::NetworkManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-    def post_process_refresh_classes
-      []
-    end
-  end
-end


### PR DESCRIPTION
Fix errors when refreshing the NetworkManager directly or via the scheduled ems_refresh_timer

```
[----] E, [2023-04-18T13:36:43.939228 #177066:96f0] ERROR -- evm: MIQ(ManageIQ::Providers::Google::NetworkManager::Refresher#refresh) EMS: [gce Network Manager], id: [5] Refresh failed
[----] E, [2023-04-18T13:36:43.940224 #177066:96f0] ERROR -- evm: [NoMethodError]: undefined method `common_instance_metadata' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2023-04-18T13:36:43.940286 #177066:96f0] ERROR -- evm: /home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-google-926d241cae74/app/models/manageiq/providers/google/inventory/collector.rb:69:in `project_instance_metadata'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-google-926d241cae74/app/models/manageiq/providers/google/inventory/parser.rb:347:in `project_key_pairs'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-google-926d241cae74/app/models/manageiq/providers/google/inventory/parser.rb:218:in `auth_key_pairs'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-google-926d241cae74/app/models/manageiq/providers/google/inventory/parser.rb:36:in `parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:42:in `block in parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in `each'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in `parse'
```