### PR TITLE
Fix google API pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
+gem "fog-google", "=1.22.0.1", :require => false, :source => "https://rubygems.manageiq.org"
+
 # Load Gemfile with dependencies from manageiq
 eval_gemfile(File.expand_path("spec/manageiq/Gemfile", __dir__))

--- a/app/models/manageiq/providers/google/inventory/collector.rb
+++ b/app/models/manageiq/providers/google/inventory/collector.rb
@@ -34,8 +34,7 @@ class ManageIQ::Providers::Google::Inventory::Collector < ManageIQ::Providers::I
   end
 
   def flavors
-    flavors_by_zone = compute.list_aggregated_machine_types.items
-    flavors_by_zone.values.flat_map(&:machine_types).compact.uniq(&:id)
+    compute.machine_types.all
   end
 
   def flavor(flavor_uid, availability_zone_uid)

--- a/spec/vcr_cassettes/manageiq/providers/google/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/google/cloud_manager/refresher.yml
@@ -8705,6 +8705,72 @@ http_interactions:
   recorded_at: Fri, 11 May 2018 14:32:50 GMT
 - request:
     method: get
+    uri: https://compute.googleapis.com/compute/v1/projects/GOOGLE_PROJECT/aggregated/machineTypes?pageToken=CgsIAxHVCAAAAAAAABIPCg1uMS1oaWdobWVtLTE2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - |-
+        ManageIQ/master fog/1.3.3 google-api-ruby-client/0.19.8 Linux/4.16.7-1-ARCH
+         (gzip)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 11 May 2018 14:32:49 GMT
+      Authorization:
+      - Bearer ya29.c.EmC4BdUk3rY5ZSoqTl2cRs6iiC5bLmCCcWMh3VPJ9Rj6F9iFB64oPIPXel9NcloXD0_BSRCyGqHVfnhvndbJoCeapl_ZsIURiI4IQTWARmoJ2oe1f5PrVVClOKVP8jGh6dk
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 11 May 2018 14:32:50 GMT
+      Date:
+      - Fri, 11 May 2018 14:32:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Etag:
+      - '"fIQOa6KYmdrz9S6QtMCRf5B1bWY=/TwZ1ZirngslFW9ymiyv2nz1petc="'
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
+        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "compute#machineTypeAggregatedList",
+         "id": "projects/GOOGLE_PROJECT/aggregated/machineTypes",
+         "items": {
+         },
+         "selfLink": "https://www.googleapis.com/compute/v1/projects/GOOGLE_PROJECT/aggregated/machineTypes"
+        }
+    http_version:
+  recorded_at: Fri, 11 May 2018 14:32:50 GMT
+- request:
+    method: get
     uri: https://compute.googleapis.com/compute/v1/projects/GOOGLE_PROJECT/aggregated/disks
     body:
       encoding: UTF-8
@@ -52138,6 +52204,72 @@ http_interactions:
             }
           ],
           "nextPageToken": "Cl0IhKP1p7HN9gI6UgoCGAEKAiAACgIYAgoHIKufgf62HgoCGAYKKyopZmVkb3JhLWNvcmVvcy0zMy0yMDIxMDEwNi0xMC0wLWdjcC14ODYtNjQKCiDYyeyKiMqGwiY=",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images",
+          "kind": "compute#imageList"
+        }
+    http_version: null
+  recorded_at: Thu, 17 Mar 2022 14:45:32 GMT
+- request:
+    method: get
+    uri: https://compute.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images?pageToken=Cl0IhKP1p7HN9gI6UgoCGAEKAiAACgIYAgoHIKufgf62HgoCGAYKKyopZmVkb3JhLWNvcmVvcy0zMy0yMDIxMDEwNi0xMC0wLWdjcC14ODYtNjQKCiDYyeyKiMqGwiY=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ManageIQ/master fog/1.18.0 google-apis-compute_v1/0.28.0 Linux/5.16.0-4-amd64
+        (gzip)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 17 Mar 2022 14:45:31 GMT
+      X-Goog-Api-Client:
+      - gl-ruby/2.7.5 gdcl/1.28.0
+      Authorization:
+      - Bearer ya29.c.b0AXv0zTPKtVXZ_uDgHfR4a1B__Y0eyx9gNwuUdjTVDUrp4uNZR0WUEufCUOib051huLrgZrQf6ltJfhwFgiOhNs4gpuvTX6TfDyDaHU-IkfPNW8URX5sOJWPf0aY8NiWHoqGnLVpziKkVnVgtBJU5T5c_C7yFINSUfy8kMBG4anCFp_so5ab-rj5pDzdB6T4F_5fHjMKKfP8YqY6UKp0jVVt0_Q4d9HBDHff5bFY................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - WIDFnzrpz_RTqeD7scwr82Agvzw=/aJpSE0chdA4LE_ixuRCBF56lCDI=
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 17 Mar 2022 14:45:32 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "projects/fedora-coreos-cloud/global/images",
+          "items": [
+          ],
           "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images",
           "kind": "compute#imageList"
         }


### PR DESCRIPTION
Fog-google has a number of models which do not use pagination arbitrarily limiting the maximum number of results to 500.

The fix has not been merged upstream yet so we have to fork the gem to apply the fix.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22756

Uses:
* https://github.com/fog/fog-google/pull/609
* https://github.com/fog/fog-google/pull/608