### PR TITLE
Cleanup any created disks if start_clone fails

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -52,5 +52,8 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
       instance = google.servers.create(clone_options)
       return instance.id
     end
+  rescue
+    cleanup_instance_disks
+    raise
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/disk.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/disk.rb
@@ -13,6 +13,13 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Disk
     create_disks([disk_attrs]).first
   end
 
+  def delete_disk(disk_attrs)
+    source.with_provider_connection do |google|
+      disk = google.disks.get(disk_attrs[:name], disk_attrs[:zone_name])
+      disk&.destroy
+    end
+  end
+
   def check_disks_ready(disks_attrs)
     source.with_provider_connection do |google|
       disks_attrs.each do |disk_attrs|

--- a/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
@@ -27,6 +27,12 @@ module ManageIQ::Providers::Google::CloudManager::Provision::StateMachine
     signal :poll_instance_disks_complete
   end
 
+  def cleanup_instance_disks
+    return if phase_context[:boot_disk].nil?
+
+    delete_disk(phase_context[:boot_disk_attrs])
+  end
+
   def poll_instance_disks_complete
     boot_disk = phase_context[:boot_disk_attrs]
 


### PR DESCRIPTION
If start_clone fails (e.g. from an invalid machine config) then the boot disk that is created during the `prepare_instance_disks` step are left over.  This will cause subsequent requests to fail if they are issued with the same target name (e.g. if you copied the request and fixed the machine config).