### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -1,22 +1,4 @@
 class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :CloudDatabase
-  require_nested :CloudDatabaseFlavor
-  require_nested :CloudVolume
-  require_nested :CloudVolumeSnapshot
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Template
-  require_nested :Vm
-
   include ManageIQ::Providers::Google::ManagerMixin
 
   supports :catalog

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Google::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.all_valid_ems_in_zone
     # Only valid to start an EventCatcher if the Pub/Sub service is enabled
     # on the project

--- a/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker <
   ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
 
   self.default_queue_name = "google"
 

--- a/app/models/manageiq/providers/google/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Google::CloudManager::Provision < ::MiqProvisionCloud
-  include_concern 'Cloning'
-  include_concern 'Disk'
-  include_concern 'StateMachine'
+  include Cloning
+  include Disk
+  include StateMachine
 end

--- a/app/models/manageiq/providers/google/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Google::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Google::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'Operations'
+  include Operations
 
   supports :capture
 

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Guest'
-  include_concern 'Power'
+  include Guest
+  include Power
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/google/container_manager.rb
+++ b/app/models/manageiq/providers/google/container_manager.rb
@@ -1,18 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Google::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-
   supports :create
 
   def self.ems_type

--- a/app/models/manageiq/providers/google/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/google/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Google::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_google_gke
   end

--- a/app/models/manageiq/providers/google/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/google/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Google::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_google_gke
   end

--- a/app/models/manageiq/providers/google/inventory.rb
+++ b/app/models/manageiq/providers/google/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Google::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/google/inventory/collector.rb
+++ b/app/models/manageiq/providers/google/inventory/collector.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Google::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   def initialize(_manager, _target)
     super
   end

--- a/app/models/manageiq/providers/google/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/collector/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Google::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/google/inventory/parser.rb
+++ b/app/models/manageiq/providers/google/inventory/parser.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Google::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   VENDOR_GOOGLE = "google".freeze
   GCP_HEALTH_STATUS_MAP = {
     "HEALTHY"   => "InService",

--- a/app/models/manageiq/providers/google/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/parser/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Google::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/google/inventory/persister.rb
+++ b/app/models/manageiq/providers/google/inventory/persister.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Google::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   def initialize_inventory_collections
     initialize_cloud_inventory_collections
     initialize_network_inventory_collections

--- a/app/models/manageiq/providers/google/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/google/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Google::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/google/network_manager.rb
+++ b/app/models/manageiq/providers/google/network_manager.rb
@@ -1,16 +1,4 @@
 class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :LoadBalancer
-  require_nested :LoadBalancerHealthCheck
-  require_nested :LoadBalancerListener
-  require_nested :LoadBalancerPool
-  require_nested :LoadBalancerPoolMember
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Google::ManagerMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854