### PR TITLE
drop use of unuspported_reason_add

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   supports :cloud_volume
   supports :create
   supports :events do
-    unsupported_reason_add(:events, _("Pub/Sub service is not enabled in this project")) unless capabilities["pubsub"]
+    _("Pub/Sub service is not enabled in this project") unless capabilities["pubsub"]
   end
   supports :metrics
   supports :provisioning

--- a/app/models/manageiq/providers/google/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/template.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Google::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -4,9 +4,7 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations
   include Power
 
   included do
-    supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-    end
+    supports(:terminate) { unsupported_reason(:control) }
   end
 
   def raw_destroy

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -3,8 +3,11 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
 
   included do
     supports :reboot_guest do
-      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
-      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+      if current_state == "on"
+        unsupported_reason(:control)
+      else
+        _("The VM is not powered on")
+      end
     end
   end
 


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
