### PR TITLE
Add rbnacl dependency for jwt

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -4,6 +4,7 @@ if [ -n "$CI" ]; then
   echo "== Installing system packages =="
   sudo apt-get update
   sudo apt-get install -y libcurl4-openssl-dev
+  sudo apt-get install -y libsodium-dev
   echo
 fi
 

--- a/manageiq-providers-google.gemspec
+++ b/manageiq-providers-google.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fog-google", "~> 1.23"
+  spec.add_dependency "rbnacl",     ">= 3.2", "< 5.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
If `RbNaCl` is defined `jwt` will use it for additional algorithms. This dependency exists in manageiq-appliance_console for net-ssh and we were implicitly using it here for google authentication, but we should explicitly declare it as a dependency.

Related: 
- https://github.com/ManageIQ/manageiq-rpm_build/pull/117/files#r520656826
- https://github.com/ManageIQ/manageiq-appliance_console/pull/248

There is talk of dropping algorithms that require rbnacl which would be great, https://github.com/jwt/ruby-jwt/issues/550
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
