### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/google/network_manager.rb
+++ b/app/models/manageiq/providers/google/network_manager.rb
@@ -22,6 +22,10 @@ class ManageIQ::Providers::Google::NetworkManager < ManageIQ::Providers::Network
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Google::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "gce_network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,9 @@
     :inventory_collections:
       :saver_strategy: default
   :gce_network:
+    # Disable scheduled full refresh for the network manager as this will be
+    # refreshed automatically by the parent cloud manager.
+    :refresh_interval: 0
     :inventory_collections:
       :saver_strategy: default
   :gke:


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug
@miq-bot add_reviewer @agrare